### PR TITLE
Fix href to generated charts

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -209,7 +209,7 @@ export async function generateOverviewHTML(config, routes) {
   const agency = first(agencies);
 
   for (const route of routes) {
-    route.relativePath = config.isLocal ? path.join('charts', sanitize(route.route_id)) : path.join('charts', sanitize(`${formatRouteName(route)}.html`));
+    route.relativePath = config.isLocal ? path.join(sanitize(route.route_id)) : path.join(sanitize(`${formatRouteName(route)}.html`));
   }
 
   const templateVars = {


### PR DESCRIPTION
The links in index.html are not working. They point to "charts\[ROUTE].html" meanwhile the generated charts are not being saved to a "charts" folder. 

This fixes the reference by making it just "[ROUTE].html" from "charts/[ROUTE].html"

This is my first time working with JavaScript, forgive me if this is not the proper fix for the issue. Seems to work okay on my end. 